### PR TITLE
feat: :sparkles: add version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - added `HelloMageForgeCommand`
 - added phpcs
 - added dependabot
+- added `VersionCommand`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,24 @@ MageForge is a Magento 2 module designed to assist frontend developers in stream
 
 ## Features
 
-...
+### `mageforge:version` Command
+
+The `mageforge:version` command displays the current module version and the latest available version.
+
+#### Usage
+
+To use the `mageforge:version` command, run the following in your terminal:
+
+```sh
+php bin/magento mageforge:version
+```
+
+Example output:
+
+```
+Module Version: 1.0.0
+Latest Version: 1.0.0
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ php bin/magento mageforge:version
 
 Example output:
 
-```
+```sh
 Module Version: 1.0.0
 Latest Version: 1.0.0
 ```

--- a/src/Console/Command/VersionCommand.php
+++ b/src/Console/Command/VersionCommand.php
@@ -15,12 +15,18 @@ class VersionCommand extends Command
     private const API_URL = 'https://api.github.com/repos/mage-forge/base/releases/latest';
     private const UNKNOWN_VERSION = 'Unknown';
 
+    /**
+     * @inheritDoc
+     */
     protected function configure(): void
     {
         $this->setName('mageforge:version');
         $this->setDescription('Displays the module version and the latest version');
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $moduleVersion = $this->getModuleVersion();
@@ -32,6 +38,9 @@ class VersionCommand extends Command
         return Cli::RETURN_SUCCESS;
     }
 
+    /**
+     * Get the module version from the composer.lock file
+     */
     private function getModuleVersion(): string
     {
         $composerLockPath = __DIR__ . '/../../../../../../composer.lock';
@@ -53,6 +62,9 @@ class VersionCommand extends Command
         return self::UNKNOWN_VERSION;
     }
 
+    /**
+     * Get the latest version from the GitHub API
+     */
     private function getLatestVersion(): string
     {
         $client = new Client();

--- a/src/Console/Command/VersionCommand.php
+++ b/src/Console/Command/VersionCommand.php
@@ -81,21 +81,29 @@ class VersionCommand extends Command
      */
     private function getLatestVersion(): string
     {
-        $client = new Client();
         try {
-            $response = $client->get(self::API_URL);
-            if ($response->getStatusCode() !== 200) {
-                throw new \Exception('Invalid response status');
-            }
-
-            $data = json_decode($response->getBody()->getContents(), true);
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new \Exception('JSON decode error');
-            }
-
-            return $data['tag_name'] ?? self::UNKNOWN_VERSION;
+            return $this->fetchLatestVersion();
         } catch (\Exception $e) {
             return self::UNKNOWN_VERSION;
         }
+    }
+
+    /**
+     * Fetch the latest version from the GitHub API
+     */
+    private function fetchLatestVersion(): string
+    {
+        $client = new Client();
+        $response = $client->get(self::API_URL);
+        if ($response->getStatusCode() !== 200) {
+            throw new \RuntimeException('Invalid response status');
+        }
+
+        $data = json_decode($response->getBody()->getContents(), true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException('JSON decode error');
+        }
+
+        return $data['tag_name'] ?? self::UNKNOWN_VERSION;
     }
 }

--- a/src/Console/Command/VersionCommand.php
+++ b/src/Console/Command/VersionCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageForge\Base\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Framework\Console\Cli;
+use GuzzleHttp\Client;
+
+class VersionCommand extends Command
+{
+    private const API_URL = 'https://api.github.com/repos/mage-forge/base/releases/latest';
+    private const UNKNOWN_VERSION = 'Unknown';
+
+    protected function configure(): void
+    {
+        $this->setName('mageforge:version');
+        $this->setDescription('Displays the module version and the latest version');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $moduleVersion = $this->getModuleVersion();
+        $latestVersion = $this->getLatestVersion();
+
+        $output->writeln("Module Version: $moduleVersion");
+        $output->writeln("Latest Version: $latestVersion");
+
+        return Cli::RETURN_SUCCESS;
+    }
+
+    private function getModuleVersion(): string
+    {
+        $composerLockPath = __DIR__ . '/../../../../../../composer.lock';
+        if (!file_exists($composerLockPath)) {
+            return self::UNKNOWN_VERSION;
+        }
+
+        $composerLock = json_decode(file_get_contents($composerLockPath), true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return self::UNKNOWN_VERSION;
+        }
+
+        foreach ($composerLock['packages'] as $package) {
+            if ($package['name'] === 'mageforge/base') {
+                return $package['version'];
+            }
+        }
+
+        return self::UNKNOWN_VERSION;
+    }
+
+    private function getLatestVersion(): string
+    {
+        $client = new Client();
+        try {
+            $response = $client->get(self::API_URL);
+        } catch (\Exception $e) {
+            return self::UNKNOWN_VERSION;
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            return self::UNKNOWN_VERSION;
+        }
+
+        $data = json_decode($response->getBody()->getContents(), true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return self::UNKNOWN_VERSION;
+        }
+
+        return $data['tag_name'] ?? self::UNKNOWN_VERSION;
+    }
+}

--- a/src/Console/Command/VersionCommand.php
+++ b/src/Console/Command/VersionCommand.php
@@ -70,7 +70,8 @@ class VersionCommand extends Command
         $client = new Client();
         try {
             $response = $client->get(self::API_URL);
-        } catch (\Exception $e) {
+        }
+        catch (\Exception $e) {
             return self::UNKNOWN_VERSION;
         }
 

--- a/src/Console/Command/VersionCommand.php
+++ b/src/Console/Command/VersionCommand.php
@@ -65,13 +65,15 @@ class VersionCommand extends Command
             return self::UNKNOWN_VERSION;
         }
 
+        $moduleVersion = self::UNKNOWN_VERSION;
         foreach ($composerLock['packages'] as $package) {
             if ($package['name'] === 'mageforge/base') {
-                return $package['version'];
+                $moduleVersion = $package['version'];
+                break;
             }
         }
 
-        return self::UNKNOWN_VERSION;
+        return $moduleVersion;
     }
 
     /**
@@ -82,19 +84,18 @@ class VersionCommand extends Command
         $client = new Client();
         try {
             $response = $client->get(self::API_URL);
+            if ($response->getStatusCode() !== 200) {
+                throw new \Exception('Invalid response status');
+            }
+
+            $data = json_decode($response->getBody()->getContents(), true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \Exception('JSON decode error');
+            }
+
+            return $data['tag_name'] ?? self::UNKNOWN_VERSION;
         } catch (\Exception $e) {
             return self::UNKNOWN_VERSION;
         }
-
-        if ($response->getStatusCode() !== 200) {
-            return self::UNKNOWN_VERSION;
-        }
-
-        $data = json_decode($response->getBody()->getContents(), true);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            return self::UNKNOWN_VERSION;
-        }
-
-        return $data['tag_name'] ?? self::UNKNOWN_VERSION;
     }
 }

--- a/src/Console/Command/VersionCommand.php
+++ b/src/Console/Command/VersionCommand.php
@@ -16,6 +16,11 @@ class VersionCommand extends Command
     private const API_URL = 'https://api.github.com/repos/mage-forge/base/releases/latest';
     private const UNKNOWN_VERSION = 'Unknown';
 
+    /**
+     * VersionCommand constructor.
+     *
+     * @param File $fileDriver
+     */
     public function __construct(
         private readonly File $fileDriver
     ) {
@@ -77,8 +82,7 @@ class VersionCommand extends Command
         $client = new Client();
         try {
             $response = $client->get(self::API_URL);
-        }
-        catch (\Exception $e) {
+        } catch (\Exception $e) {
             return self::UNKNOWN_VERSION;
         }
 

--- a/src/Console/Command/VersionCommand.php
+++ b/src/Console/Command/VersionCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MageForge\Base\Console\Command;
 
+use MageForge\Base\Exception\FetchLatestVersionException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -96,12 +97,12 @@ class VersionCommand extends Command
         $client = new Client();
         $response = $client->get(self::API_URL);
         if ($response->getStatusCode() !== 200) {
-            throw new \RuntimeException('Invalid response status');
+            throw new FetchLatestVersionException('Invalid response status');
         }
 
         $data = json_decode($response->getBody()->getContents(), true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \RuntimeException('JSON decode error');
+            throw new FetchLatestVersionException('JSON decode error');
         }
 
         return $data['tag_name'] ?? self::UNKNOWN_VERSION;

--- a/src/Console/Command/VersionCommand.php
+++ b/src/Console/Command/VersionCommand.php
@@ -9,11 +9,18 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Magento\Framework\Console\Cli;
 use GuzzleHttp\Client;
+use Magento\Framework\Filesystem\Driver\File;
 
 class VersionCommand extends Command
 {
     private const API_URL = 'https://api.github.com/repos/mage-forge/base/releases/latest';
     private const UNKNOWN_VERSION = 'Unknown';
+
+    public function __construct(
+        private readonly File $fileDriver
+    ) {
+        parent::__construct();
+    }
 
     /**
      * @inheritDoc
@@ -44,11 +51,11 @@ class VersionCommand extends Command
     private function getModuleVersion(): string
     {
         $composerLockPath = __DIR__ . '/../../../../../../composer.lock';
-        if (!file_exists($composerLockPath)) {
+        if (!$this->fileDriver->isExists($composerLockPath)) {
             return self::UNKNOWN_VERSION;
         }
 
-        $composerLock = json_decode(file_get_contents($composerLockPath), true);
+        $composerLock = json_decode($this->fileDriver->fileGetContents($composerLockPath), true);
         if (json_last_error() !== JSON_ERROR_NONE) {
             return self::UNKNOWN_VERSION;
         }

--- a/src/Exception/FetchLatestVersionException.php
+++ b/src/Exception/FetchLatestVersionException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageForge\Base\Exception;
+
+class FetchLatestVersionException extends \RuntimeException
+{
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -13,6 +13,10 @@
                     name="mageforge_base_hello"
                     xsi:type="object"
                 >MageForge\Base\Console\Command\HelloMageForgeCommand</item>
+                <item
+                    name="mageforge_base_version"
+                    xsi:type="object"
+                >MageForge\Base\Console\Command\VersionCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
It should work once we publish a release.
Currently it only shows:

```bash

$ magento mageforge:version
Module Version: dev-main
Latest Version: Unknown
```